### PR TITLE
Fix to calculate pages_compressed from "stored in" to "occupied by"

### DIFF
--- a/used-mem
+++ b/used-mem
@@ -133,7 +133,7 @@ calculate_memory() {
         local pages_inactive=$(echo "$vm_stat" | awk '/Pages inactive/ {print $3}' | tr -d '.')
         local pages_speculative=$(echo "$vm_stat" | awk '/Pages speculative/ {print $3}' | tr -d '.')
         local pages_wired=$(echo "$vm_stat" | awk '/Pages wired down/ {print $4}' | tr -d '.')
-        local pages_compressed=$(echo "$vm_stat" | awk '/Pages stored in compressor/ {print $5}' | tr -d '.')
+        local pages_compressed=$(echo "$vm_stat" | awk '/Pages occupied by compressor/ {print $5}' | tr -d '.')
         local pages_purgeable=$(echo "$vm_stat" | awk '/Pages purgeable/ {print $3}' | tr -d '.')
         local pages_file=$(echo "$vm_stat" | awk '/File-backed pages/ {print $3}' | tr -d '.')
         local pages_app=$(echo "$vm_stat" | awk '/Anonymous pages/ {print $3}' | tr -d '.')


### PR DESCRIPTION
使わせていただいて、Macでのメモリ使用量の表示がどうにもおかしかったので調べてみました。
参考） http://www.songmu.jp/riji/entry/2015-05-08-mac-memory.html